### PR TITLE
Enable using FactoryGirl factories

### DIFF
--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,7 @@
+if defined? FactoryGirl
+  FactoryGirl.find_definitions
+
+  RSpec.configure do |config|
+    config.include FactoryGirl::Syntax::Methods
+  end
+end


### PR DESCRIPTION
Factories do not work for older spree versions, as there's FactoryGirl instead of FactoryBot there.