### PR TITLE
Change integer limit in transactions

### DIFF
--- a/db/migrate/20190128124135_change_id_limit_in_spree_avatax_official_transactions.rb
+++ b/db/migrate/20190128124135_change_id_limit_in_spree_avatax_official_transactions.rb
@@ -1,0 +1,9 @@
+class ChangeIdLimitInSpreeAvataxOfficialTransactions < SpreeExtension::Migration[4.2]
+  def up
+    change_column :spree_avatax_official_transactions, :id, :integer, limit: 8
+  end
+
+  def down
+    change_column :spree_avatax_official_transactions, :id, :integer, limit: 4
+  end
+end


### PR DESCRIPTION
Default limit of 4 is not enough for transaction ids.