### PR TITLE
Add code field to spree_avatax_official_transactions

### DIFF
--- a/app/models/spree_avatax_official/transaction.rb
+++ b/app/models/spree_avatax_official/transaction.rb
@@ -6,7 +6,7 @@ module SpreeAvataxOfficial
 
     with_options presence: true do
       validates :code, uniqueness: true
-      validates :order, uniqueness: { scope: :transaction_type }
+      validates :order
       validates :transaction_type
     end
 

--- a/db/migrate/20190122154119_create_spree_avatax_official_transactions.rb
+++ b/db/migrate/20190122154119_create_spree_avatax_official_transactions.rb
@@ -1,17 +1,10 @@
 class CreateSpreeAvataxOfficialTransactions < SpreeExtension::Migration[4.2]
   def change
-    create_table(:spree_avatax_official_transactions, id: false) do |t|
-      t.integer    :id,                null: false, index: { unique: true }
+    create_table :spree_avatax_official_transactions do |t|
       t.references :order,             null: false, index: true
       t.string     :transaction_type,  null: false, index: true
+      t.string     :code,              null: false, index: { unique: true }
       t.timestamps
     end
-
-    add_index(
-      :spree_avatax_official_transactions,
-      %i[transaction_type order_id],
-      unique: true,
-      name: 'index_transactions_on_transaction_type_and_order_id'
-    )
   end
 end

--- a/db/migrate/20190128124135_change_id_limit_in_spree_avatax_official_transactions.rb
+++ b/db/migrate/20190128124135_change_id_limit_in_spree_avatax_official_transactions.rb
@@ -1,9 +1,0 @@
-class ChangeIdLimitInSpreeAvataxOfficialTransactions < SpreeExtension::Migration[4.2]
-  def up
-    change_column :spree_avatax_official_transactions, :id, :integer, limit: 8
-  end
-
-  def down
-    change_column :spree_avatax_official_transactions, :id, :integer, limit: 4
-  end
-end

--- a/db/migrate/20190129141922_add_code_to_spree_avatax_official_transactions.rb
+++ b/db/migrate/20190129141922_add_code_to_spree_avatax_official_transactions.rb
@@ -1,9 +1,0 @@
-class AddCodeToSpreeAvataxOfficialTransactions < SpreeExtension::Migration[4.2]
-  def change
-    change_column :spree_avatax_official_transactions, :id, :primary_key
-    remove_index :spree_avatax_official_transactions, :id
-
-    add_column :spree_avatax_official_transactions, :code, :string
-    add_index :spree_avatax_official_transactions, :code, unique: true
-  end
-end


### PR DESCRIPTION
Unfortunately, I've run into an issue when making spree_avatax_offcial_transacations.id again a primary_key in Postgres. That's why I've decided to take the easier approach and modify previous migrations as we don't have any relevant data in our environments.