### PR TITLE
Fix refundLines for refund invoice

### DIFF
--- a/spec/presenters/spree_avatax_official/transactions/refund_presenter_spec.rb
+++ b/spec/presenters/spree_avatax_official/transactions/refund_presenter_spec.rb
@@ -36,7 +36,7 @@ describe SpreeAvataxOfficial::Transactions::RefundPresenter do
         inventory_unit              = order.inventory_units.first
         return_auth.inventory_units = [inventory_unit]
         result[:refundType]         = 'Partial'
-        result[:refundLines]        = [SpreeAvataxOfficial::LineItemPresenter.new(line_item: inventory_unit.line_item).to_json]
+        result[:refundLines]        = [inventory_unit.variant.sku]
 
         expect(subject.to_json).to eq result
       end

--- a/spec/vcr/spree_avatax_official/transactions/refund/partial_refund_success.yml
+++ b/spec/vcr/spree_avatax_official/transactions/refund/partial_refund_success.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox-rest.avatax.com/api/v2/companies/test1/transactions/REFUNDTEST321/refund
+    body:
+      encoding: UTF-8
+      string: '{"refundTransactionCode":null,"referenceCode":"REFUNDTEST321","refundDate":"2019-02-01","refundType":"Partial","refundLines":["SKU-1"]}'
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - AvaTax Ruby Gem 18.12.0
+      X-Avalara-Client:
+      - ";;RubySdk;18.12.0;"
+      Authorization:
+      - "<AVATAX_TOKEN>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 01 Feb 2019 13:30:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Location:
+      - "/api/v2/companies/848107/transactions/6810775763"
+      Server:
+      - Kestrel
+      Serverduration:
+      - '00:00:00.0778485'
+      Databasecalls:
+      - '1'
+      Databaseduration:
+      - '00:00:00.0000020'
+      Serviceduration:
+      - '00:00:00.0595710'
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: '{"id":6810775763,"code":"3840c2ef-38cb-4d5f-9d78-eadeff46226f","companyId":848107,"date":"2019-02-01","status":"Committed","type":"ReturnInvoice","batchCode":"","currencyCode":"USD","customerUsageType":"","entityUseCode":"","customerVendorCode":"joey.ullrich@keeblerbosco.ca","customerCode":"joey.ullrich@keeblerbosco.ca","exemptNo":"","reconciled":false,"locationCode":"","reportingLocationCode":"","purchaseOrderNo":"","referenceCode":"REFUNDTEST321","salespersonCode":"","taxOverrideType":"None","taxOverrideAmount":0.0000,"taxOverrideReason":"","totalAmount":-10.0000,"totalExempt":0.0000,"totalDiscount":0.0000,"totalTax":-0.8000,"totalTaxable":-10.0000,"totalTaxCalculated":-0.8000,"adjustmentReason":"NotAdjusted","adjustmentDescription":"","locked":false,"region":"PA","country":"US","version":1,"softwareVersion":"19.1.0.16","originAddressId":5390590051,"destinationAddressId":5390590051,"exchangeRateEffectiveDate":"2019-01-31","exchangeRate":1.0000,"isSellerImporterOfRecord":true,"description":"","email":"","businessIdentificationNo":"","modifiedDate":"2019-02-01T13:30:08.313","modifiedUserId":356147,"taxDate":"2019-02-01T00:00:00","lines":[{"id":7792193446,"transactionId":6810775763,"lineNumber":"SKU-1","boundaryOverrideId":0,"customerUsageType":"","entityUseCode":"","description":"","destinationAddressId":11596083654,"originAddressId":11596083654,"discountAmount":0.0000,"discountTypeId":0,"exemptAmount":0.0000,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"isSSTP":false,"itemCode":"","lineAmount":-10.0000,"quantity":1.0000,"ref1":"","ref2":"","reportingDate":"2019-02-01","revAccount":"","sourcing":"Origin","tax":-0.8000,"taxableAmount":-10.0000,"taxCalculated":-0.8000,"taxCode":"P0000000","taxCodeId":8087,"taxDate":"2019-01-31","taxEngine":"","taxOverrideType":"TaxAmount","businessIdentificationNo":"","taxOverrideAmount":-0.8000,"taxOverrideReason":"Refund
+        request on 2019-02-01","taxIncluded":false,"details":[{"id":7595256651,"transactionLineId":7792193446,"transactionId":6810775763,"addressId":11596083654,"country":"US","region":"PA","countyFIPS":"","stateFIPS":"42","exemptAmount":0.0000,"exemptReasonId":4,"inState":true,"jurisCode":"42","jurisName":"PENNSYLVANIA","jurisdictionId":49,"signatureCode":"BKTQ","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0000,"nonTaxableRuleId":0,"nonTaxableType":"RateRule","rate":0.060000,"rateRuleId":1457985,"rateSourceId":3,"serCode":"","sourcing":"Origin","tax":-0.6000,"taxableAmount":-10.0000,"taxType":"Sales","taxSubTypeId":"S","taxTypeGroupId":"SalesAndUse","taxName":"PA
+        STATE TAX","taxAuthorityTypeId":45,"taxRegionId":4014900,"taxCalculated":-0.6000,"taxOverride":-0.6000,"rateType":"General","rateTypeCode":"G","taxableUnits":-10.0000,"nonTaxableUnits":0.0000,"exemptUnits":0.0000,"unitOfBasis":"PerCurrencyUnit","isNonPassThru":false},{"id":9595256650,"transactionLineId":7792193446,"transactionId":6810775763,"addressId":11596083654,"country":"US","region":"PA","countyFIPS":"","stateFIPS":"42","exemptAmount":0.0000,"exemptReasonId":4,"inState":true,"jurisCode":"101","jurisName":"PHILADELPHIA","jurisdictionId":2311,"signatureCode":"BMWV","stateAssignedNo":"51","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0000,"nonTaxableRuleId":0,"nonTaxableType":"RateRule","rate":0.020000,"rateRuleId":1458005,"rateSourceId":3,"serCode":"","sourcing":"Origin","tax":-0.2000,"taxableAmount":-10.0000,"taxType":"Sales","taxSubTypeId":"S","taxTypeGroupId":"SalesAndUse","taxName":"PA
+        COUNTY TAX","taxAuthorityTypeId":45,"taxRegionId":4014900,"taxCalculated":-0.2000,"taxOverride":-0.2000,"rateType":"General","rateTypeCode":"G","taxableUnits":-10.0000,"nonTaxableUnits":0.0000,"exemptUnits":0.0000,"unitOfBasis":"PerCurrencyUnit","isNonPassThru":false}],"nonPassthroughDetails":[],"lineLocationTypes":[{"documentLineLocationTypeId":12652156661,"documentLineId":7792193446,"documentAddressId":11596083654,"locationTypeCode":"PointOfOrderOrigin"},{"documentLineLocationTypeId":10435098520,"documentLineId":7792193446,"documentAddressId":11596083654,"locationTypeCode":"PointOfOrderAcceptance"},{"documentLineLocationTypeId":8435098520,"documentLineId":7792193446,"documentAddressId":11596083654,"locationTypeCode":"ShipTo"},{"documentLineLocationTypeId":6435098520,"documentLineId":7792193446,"documentAddressId":11596083654,"locationTypeCode":"ShipFrom"}],"parameters":{},"hsCode":"","costInsuranceFreight":0.0000,"vatCode":"","vatNumberTypeId":0}],"addresses":[{"id":5390590051,"transactionId":6810775763,"boundaryLevel":"Zip5","line1":"822
+        Reed St","line2":"","line3":"","city":"Philadelphia","region":"PA","postalCode":"19147-5736","country":"US","taxRegionId":0},{"id":11596083654,"transactionId":6810775763,"boundaryLevel":"Address","line1":"822
+        Reed St","line2":"","line3":"","city":"Philadelphia","region":"PA","postalCode":"19147-5736","country":"US","taxRegionId":4014900,"latitude":"39.931649","longitude":"-75.159058"}],"locationTypes":[{"documentLocationTypeId":10848883687,"documentId":6810775763,"documentAddressId":5390590051,"locationTypeCode":"PointOfOrderOrigin"},{"documentLocationTypeId":8645102881,"documentId":6810775763,"documentAddressId":5390590051,"locationTypeCode":"PointOfOrderAcceptance"},{"documentLocationTypeId":6645102881,"documentId":6810775763,"documentAddressId":5390590051,"locationTypeCode":"ShipTo"},{"documentLocationTypeId":4645102881,"documentId":6810775763,"documentAddressId":5390590051,"locationTypeCode":"ShipFrom"}],"summary":[{"country":"US","region":"PA","jurisType":"State","jurisCode":"42","jurisName":"PENNSYLVANIA","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Sales","taxName":"PA
+        STATE TAX","rateType":"General","taxable":-10.00,"rate":0.060000,"tax":-0.60,"taxCalculated":-0.60,"nonTaxable":0.00,"exemption":0.00},{"country":"US","region":"PA","jurisType":"County","jurisCode":"101","jurisName":"PHILADELPHIA","taxAuthorityType":45,"stateAssignedNo":"51","taxType":"Sales","taxName":"PA
+        COUNTY TAX","rateType":"General","taxable":-10.00,"rate":0.020000,"tax":-0.20,"taxCalculated":-0.20,"nonTaxable":0.00,"exemption":0.00}],"parameters":{}}'
+    http_version:
+  recorded_at: Fri, 01 Feb 2019 13:30:08 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
It turns out that for partial refunds we only need to send line item numbers (which in our case means skus), that's all data avalara uses here.