### PR TITLE
Fix transaction type for refunds

### DIFF
--- a/app/models/spree_avatax_official/transaction.rb
+++ b/app/models/spree_avatax_official/transaction.rb
@@ -2,12 +2,12 @@ module SpreeAvataxOfficial
   class Transaction < ActiveRecord::Base
     SALES_ORDER    = 'SalesOrder'.freeze
     SALES_INVOICE  = 'SalesInvoice'.freeze
-    REFUND_INVOICE = 'RefundInvoice'.freeze
+    RETURN_INVOICE = 'ReturnInvoice'.freeze
 
     AVAILABLE_TRANSACTION_TYPES = [
       SALES_ORDER,
       SALES_INVOICE,
-      REFUND_INVOICE
+      RETURN_INVOICE
     ].freeze
 
     belongs_to :order, class_name: 'Spree::Order'
@@ -22,7 +22,7 @@ module SpreeAvataxOfficial
 
     scope :sales_orders,    -> { with_kind(SALES_ORDER) }
     scope :sales_invoices,  -> { with_kind(SALES_INVOICE) }
-    scope :refund_invoices, -> { with_kind(REFUND_INVOICE) }
+    scope :return_invoices, -> { with_kind(RETURN_INVOICE) }
     scope :with_kind,       ->(*s) { where(transaction_type: s) }
   end
 end

--- a/app/services/spree_avatax_official/transactions/refund_service.rb
+++ b/app/services/spree_avatax_official/transactions/refund_service.rb
@@ -29,7 +29,7 @@ module SpreeAvataxOfficial
         SpreeAvataxOfficial::Transactions::SaveCodeService.call(
           code:  code,
           order: order,
-          type:  SpreeAvataxOfficial::Transaction::SALES_INVOICE
+          type:  SpreeAvataxOfficial::Transaction::RETURN_INVOICE
         )
       end
     end

--- a/spec/services/spree_avatax_official/transactions/refund_service_spec.rb
+++ b/spec/services/spree_avatax_official/transactions/refund_service_spec.rb
@@ -18,6 +18,7 @@ describe SpreeAvataxOfficial::Transactions::RefundService do
           expect(result.success?).to eq true
           expect(response['type']).to eq 'ReturnInvoice'
           expect(SpreeAvataxOfficial::Transaction.count).to eq 1
+          expect(SpreeAvataxOfficial::Transaction.last.transaction_type).to eq 'ReturnInvoice'
         end
       end
 


### PR DESCRIPTION
Creating a refund results in a new ReturnInvoice, not RefundInvoice.