### PR TITLE
Remove SalesOrder as transaction type

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -6,10 +6,6 @@ module SpreeAvataxOfficial
 
         base.has_many :avatax_transactions, class_name: 'SpreeAvataxOfficial::Transaction'
 
-        base.has_one :avatax_sales_order_transaction, -> { where(transaction_type: 'SalesOrder') },
-                     class_name: 'SpreeAvataxOfficial::Transaction',
-                     inverse_of: :order
-
         base.has_one :avatax_sales_invoice_transaction, -> { where(transaction_type: 'SalesInvoice') },
                      class_name: 'SpreeAvataxOfficial::Transaction',
                      inverse_of: :order

--- a/app/models/spree_avatax_official/transaction.rb
+++ b/app/models/spree_avatax_official/transaction.rb
@@ -6,7 +6,6 @@ module SpreeAvataxOfficial
     DEFAULT_ADJUSTMENT_REASON = 'Other'.freeze
 
     AVAILABLE_TRANSACTION_TYPES = [
-      SALES_ORDER,
       SALES_INVOICE,
       RETURN_INVOICE
     ].freeze
@@ -21,7 +20,6 @@ module SpreeAvataxOfficial
 
     validates :transaction_type, inclusion: { in: AVAILABLE_TRANSACTION_TYPES }
 
-    scope :sales_orders,    -> { with_kind(SALES_ORDER) }
     scope :sales_invoices,  -> { with_kind(SALES_INVOICE) }
     scope :return_invoices, -> { with_kind(RETURN_INVOICE) }
     scope :with_kind,       ->(*s) { where(transaction_type: s) }

--- a/spec/factories/spree_avatax_official/transaction_factory.rb
+++ b/spec/factories/spree_avatax_official/transaction_factory.rb
@@ -1,6 +1,6 @@
 FACTORY_BOT_CLASS.define do
   factory :spree_avatax_official_transaction, class: SpreeAvataxOfficial::Transaction do
-    transaction_type { 'SalesOrder' }
+    transaction_type { 'SalesInvoice' }
     sequence(:code, &:to_s)
     association :order, factory: :order
   end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -4,17 +4,8 @@ describe Spree::Order do
   describe 'associations' do
     let(:order) { create(:order) }
 
-    describe 'avatax_sales_order_transaction' do
-      let!(:sales_order_transaction) { create(:spree_avatax_official_transaction, order: order, transaction_type: 'SalesOrder') }
-      let!(:sales_invoice_transaction) { create(:spree_avatax_official_transaction, order: order, transaction_type: 'SalesInvoice') }
-
-      it 'returns SpreeAvataxOfficial::Transaction object with transaction_type: SalesOrder' do
-        expect(order.avatax_sales_order_transaction).to eq sales_order_transaction
-      end
-    end
-
     describe 'avatax_sales_invoice_transaction' do
-      let!(:sales_order_transaction) { create(:spree_avatax_official_transaction, order: order, transaction_type: 'SalesOrder') }
+      let!(:return_invoice_transaction) { create(:spree_avatax_official_transaction, order: order, transaction_type: 'ReturnInvoice') }
       let!(:sales_invoice_transaction) { create(:spree_avatax_official_transaction, order: order, transaction_type: 'SalesInvoice') }
 
       it 'returns SpreeAvataxOfficial::Transaction object with transaction_type: SalesInvoice' do
@@ -104,7 +95,7 @@ describe Spree::Order do
   end
 
   describe '#avatax_sales_invoice_code' do
-    let(:transaction) { create(:spree_avatax_official_transaction, transaction_type: 'SalesInvoice') }
+    let(:transaction) { create(:spree_avatax_official_transaction) }
     let(:order)       { transaction.order }
 
     it 'returns code of avatax sales invoice' do


### PR DESCRIPTION
SalesOrder transactions are not recorded in Avatax database, we don't need to store them either.