### PR TITLE
Fix AddUuidToSpreeLineItemsAndSpreeShipments migration to create index

### DIFF
--- a/db/migrate/20190225145808_add_uuid_to_spree_line_items_and_spree_shipments.rb
+++ b/db/migrate/20190225145808_add_uuid_to_spree_line_items_and_spree_shipments.rb
@@ -1,6 +1,13 @@
 class AddUuidToSpreeLineItemsAndSpreeShipments < SpreeExtension::Migration[4.2]
   def change
-    add_column(:spree_line_items, :avatax_uuid, :string, index: { unique: true }) unless column_exists?(:spree_line_items, :avatax_uuid)
-    add_column(:spree_shipments, :avatax_uuid, :string, index: { unique: true }) unless column_exists?(:spree_shipments, :avatax_uuid)
+    unless column_exists?(:spree_line_items, :avatax_uuid)
+      add_column :spree_line_items, :avatax_uuid, :string
+      add_index  :spree_line_items, :avatax_uuid, unique: true
+    end
+
+    return if column_exists?(:spree_shipments, :avatax_uuid)
+
+    add_column :spree_shipments, :avatax_uuid, :string
+    add_index  :spree_shipments, :avatax_uuid, unique: true
   end
 end


### PR DESCRIPTION
It turns out that `add_column` method doesn't support `index: true` parameter:
https://github.com/rails/rails/issues/20400