### PR TITLE
Do not require included_in_price column in zones

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -2,10 +2,13 @@ module SpreeAvataxOfficial
   module Spree
     module LineItemDecorator
       delegate :tax_zone, to: :order
-      delegate :included_in_price, to: :tax_zone
 
       def self.prepended(base)
         base.include ::SpreeAvataxOfficial::HasUuid
+      end
+
+      def included_in_price
+        tax_zone.try(:included_in_price)
       end
 
       def update_tax_charge

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -2,10 +2,13 @@ module SpreeAvataxOfficial
   module Spree
     module ShipmentDecorator
       delegate :tax_zone, to: :order
-      delegate :included_in_price, to: :tax_zone
 
       def self.prepended(base)
         base.include ::SpreeAvataxOfficial::HasUuid
+      end
+
+      def included_in_price
+        tax_zone.try(:included_in_price)
       end
 
       def tax_category


### PR DESCRIPTION
We can pass `nil` to AvaTax (`If this value is null or false, the final price will equal amount plus whatever taxes apply to this line.`).