### PR TITLE
Fix included value in tax adjustments

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -8,7 +8,7 @@ module SpreeAvataxOfficial
       end
 
       def included_in_price
-        tax_zone.try(:included_in_price)
+        tax_zone.try(:included_in_price) || false
       end
 
       def update_tax_charge

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -8,7 +8,7 @@ module SpreeAvataxOfficial
       end
 
       def included_in_price
-        tax_zone.try(:included_in_price)
+        tax_zone.try(:included_in_price) || false
       end
 
       def tax_category


### PR DESCRIPTION
`nil` is fine for AvaTax, but it turns out we need `true` or `false` to create correct tax adjustments https://github.com/spark-solutions/spree_avatax_official/blob/master/app/services/spree_avatax_official/create_tax_adjustments_service.rb#L93