### PR TITLE
Add limit for address lines

### DIFF
--- a/app/presenters/spree_avatax_official/item_presenter.rb
+++ b/app/presenters/spree_avatax_official/item_presenter.rb
@@ -68,8 +68,8 @@ module SpreeAvataxOfficial
       stock_location = inventory_units.first.shipment.stock_location
 
       {
-        line1:      stock_location.address1,
-        line2:      stock_location.address2,
+        line1:      stock_location.address1.try(:first, 50),
+        line2:      stock_location.address2.try(:first, 50),
         city:       stock_location.city,
         region:     stock_location.state.try(:abbr),
         country:    stock_location.country.try(:iso),

--- a/app/presenters/spree_avatax_official/ship_to_address_presenter.rb
+++ b/app/presenters/spree_avatax_official/ship_to_address_presenter.rb
@@ -4,10 +4,10 @@ module SpreeAvataxOfficial
       @address = address
     end
 
-    def to_json
+    def to_json # rubocop:disable Metrics/AbcSize
       {
-        line1:      address.address1,
-        line2:      address.address2,
+        line1:      address.address1.try(:first, 50),
+        line2:      address.address2.try(:first, 50),
         city:       address.city,
         region:     address.state.try(:abbr),
         country:    address.country.try(:iso),

--- a/spec/presenters/spree_avatax_official/item_presenter_spec.rb
+++ b/spec/presenters/spree_avatax_official/item_presenter_spec.rb
@@ -91,12 +91,22 @@ describe SpreeAvataxOfficial::ItemPresenter do
           end
         end
 
-        it 'serializes the object' do
-          item.order.update(ship_address: create(:usa_address))
+        before { item.order.update(ship_address: create(:usa_address)) }
 
+        it 'serializes the object' do
           result[:addresses] = ship_from_address.merge(ship_to_address)
 
           expect(subject.to_json).to eq result
+        end
+
+        context 'with address line longer than 50 characters' do
+          let(:very_long_address) { FFaker::Lorem.characters(100) }
+
+          it 'takes first 50 characters from the address line to prevent error' do
+            stock_location.update(address1: very_long_address)
+
+            expect(subject.to_json[:addresses]['ShipFrom'][:line1]).to eq very_long_address.first(50)
+          end
         end
       end
 

--- a/spec/presenters/spree_avatax_official/ship_to_address_presenter_spec.rb
+++ b/spec/presenters/spree_avatax_official/ship_to_address_presenter_spec.rb
@@ -20,5 +20,15 @@ describe SpreeAvataxOfficial::ShipToAddressPresenter do
     it 'serializes the object' do
       expect(subject).to eq result
     end
+
+    context 'with address line longer than 50 characters' do
+      let(:very_long_address) { FFaker::Lorem.characters(100) }
+
+      it 'takes first 50 characters from the address line to prevent error' do
+        address.address1 = very_long_address
+
+        expect(subject[:line1]).to eq very_long_address.first(50)
+      end
+    end
   end
 end


### PR DESCRIPTION
Line length must be between 1 and 50 characters, otherwise avatax throws an error.