### PR TITLE
Custom transaction codes for GetByCodeService

### DIFF
--- a/app/services/spree_avatax_official/transactions/get_by_code_service.rb
+++ b/app/services/spree_avatax_official/transactions/get_by_code_service.rb
@@ -1,8 +1,8 @@
 module SpreeAvataxOfficial
   module Transactions
     class GetByCodeService < SpreeAvataxOfficial::Base
-      def call(order:, type: 'SalesInvoice')
-        code = transaction_code(order, type)
+      def call(order:, type: 'SalesInvoice', code: nil)
+        code ||= transaction_code(order, type)
 
         return failure(::Spree.t('spree_avatax_official.get_by_code_service.missing_code')) if code.nil?
 

--- a/spec/services/spree_avatax_official/transactions/create_service_spec.rb
+++ b/spec/services/spree_avatax_official/transactions/create_service_spec.rb
@@ -99,7 +99,7 @@ describe SpreeAvataxOfficial::Transactions::CreateService do
             expect(result.success?).to eq false
             expect(response['error']).to be_present
             expect(response['error']['code']).to eq 'ConnectionError'
-            expect(response['error']['message']).to eq 'Faraday::TimeoutError - Net::ReadTimeout'
+            expect(response['error']['message'] =~ /Net::ReadTimeout/).to be_truthy
           end
         end
       end

--- a/spec/services/spree_avatax_official/transactions/get_by_code_service_spec.rb
+++ b/spec/services/spree_avatax_official/transactions/get_by_code_service_spec.rb
@@ -46,6 +46,17 @@ describe SpreeAvataxOfficial::Transactions::GetByCodeService do
           end
         end
       end
+
+      context 'with custom transaction code' do
+        let(:params) { { order: order, type: 'ReturnInvoice', code: 'custom123' } }
+
+        it 'returns success' do
+          VCR.use_cassette('spree_avatax_official/transactions/get_by_code/order_with_custom_code_success') do
+            expect(subject.success?).to eq true
+            expect(subject.value['code']).to eq 'custom123'
+          end
+        end
+      end
     end
 
     context 'with incorrect params' do

--- a/spec/vcr/spree_avatax_official/transactions/get_by_code/order_with_custom_code_success.yml
+++ b/spec/vcr/spree_avatax_official/transactions/get_by_code/order_with_custom_code_success.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-rest.avatax.com/api/v2/companies/test1/transactions/custom123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - AvaTax Ruby Gem 19.7.0
+      X-Avalara-Client:
+      - a0o0b000005HsXPAA0;Spree by Spark;RubySdk;19.7.0;
+      Authorization:
+      - "<AVATAX_TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 Sep 2019 09:02:49 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Location:
+      - "/api/v2/companies/848107/transactions/10814105362"
+      X-Content-Type-Options:
+      - nosniff
+      Serverduration:
+      - '00:00:00.0148971'
+    body:
+      encoding: UTF-8
+      string: '{"id":10814105362,"code":"custom123","companyId":848107,"date":"2019-02-01","paymentDate":"1900-01-01","status":"Saved","type":"ReturnInvoice","batchCode":"","currencyCode":"USD","customerUsageType":"","entityUseCode":"","customerVendorCode":"arnetta_hyatt@ledner.info","customerCode":"arnetta_hyatt@ledner.info","exemptNo":"","reconciled":false,"locationCode":"","reportingLocationCode":"","purchaseOrderNo":"","referenceCode":"","salespersonCode":"","taxOverrideType":"None","taxOverrideAmount":0.0000,"taxOverrideReason":"","totalAmount":10.0000,"totalExempt":0.0000,"totalDiscount":0.0000,"totalTax":0.8000,"totalTaxable":10.0000,"totalTaxCalculated":0.8000,"adjustmentReason":"NotAdjusted","adjustmentDescription":"","locked":false,"region":"PA","country":"US","version":1,"softwareVersion":"19.1.0.16","originAddressId":7390566442,"destinationAddressId":7390566442,"exchangeRateEffectiveDate":"2019-02-01","exchangeRate":1.0000,"isSellerImporterOfRecord":true,"description":"","email":"","businessIdentificationNo":"","modifiedDate":"2019-02-01T12:18:32.627","modifiedUserId":356147,"taxDate":"2019-02-01T00:00:00","lines":[{"id":12000501468,"transactionId":10814105362,"lineNumber":"SKU-2","boundaryOverrideId":0,"customerUsageType":"","entityUseCode":"","description":"","destinationAddressId":7390566442,"originAddressId":7390566442,"discountAmount":0.0000,"discountTypeId":0,"exemptAmount":0.0000,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"isSSTP":false,"itemCode":"","lineAmount":10.0000,"quantity":1.0000,"ref1":"","ref2":"","reportingDate":"2019-02-01","revAccount":"","sourcing":"Origin","tax":0.8000,"taxableAmount":10.0000,"taxCalculated":0.8000,"taxCode":"P0000000","taxCodeId":8087,"taxDate":"2019-02-01","taxEngine":"","taxOverrideType":"None","businessIdentificationNo":"","taxOverrideAmount":0.0000,"taxOverrideReason":"","taxIncluded":false,"details":[{"id":15595227240,"transactionLineId":12000501468,"transactionId":10814105362,"addressId":7390566442,"country":"US","region":"PA","countyFIPS":"","stateFIPS":"42","exemptAmount":0.0000,"exemptReasonId":4,"inState":true,"jurisCode":"42","jurisName":"PENNSYLVANIA","jurisdictionId":49,"signatureCode":"BKTQ","stateAssignedNo":"","jurisType":"STA","jurisdictionType":"State","nonTaxableAmount":0.0000,"nonTaxableRuleId":0,"nonTaxableType":"RateRule","rate":0.060000,"rateRuleId":1457985,"rateSourceId":3,"serCode":"","sourcing":"Origin","tax":0.6000,"taxableAmount":10.0000,"taxType":"Sales","taxSubTypeId":"S","taxTypeGroupId":"SalesAndUse","taxName":"PA
+        STATE TAX","taxAuthorityTypeId":45,"taxRegionId":4014900,"taxCalculated":0.6000,"taxOverride":0.0000,"rateType":"General","rateTypeCode":"G","taxableUnits":10.0000,"nonTaxableUnits":0.0000,"exemptUnits":0.0000,"unitOfBasis":"PerCurrencyUnit","isNonPassThru":false},{"id":27604771666,"transactionLineId":12000501468,"transactionId":10814105362,"addressId":7390566442,"country":"US","region":"PA","countyFIPS":"","stateFIPS":"42","exemptAmount":0.0000,"exemptReasonId":4,"inState":true,"jurisCode":"101","jurisName":"PHILADELPHIA","jurisdictionId":2311,"signatureCode":"BMWV","stateAssignedNo":"51","jurisType":"CTY","jurisdictionType":"County","nonTaxableAmount":0.0000,"nonTaxableRuleId":0,"nonTaxableType":"RateRule","rate":0.020000,"rateRuleId":1458005,"rateSourceId":3,"serCode":"","sourcing":"Origin","tax":0.2000,"taxableAmount":10.0000,"taxType":"Sales","taxSubTypeId":"S","taxTypeGroupId":"SalesAndUse","taxName":"PA
+        COUNTY TAX","taxAuthorityTypeId":45,"taxRegionId":4014900,"taxCalculated":0.2000,"taxOverride":0.0000,"rateType":"General","rateTypeCode":"G","taxableUnits":10.0000,"nonTaxableUnits":0.0000,"exemptUnits":0.0000,"unitOfBasis":"PerCurrencyUnit","isNonPassThru":false}],"nonPassthroughDetails":[],"lineLocationTypes":[{"documentLineLocationTypeId":8435041518,"documentLineId":12000501468,"documentAddressId":7390566442,"locationTypeCode":"ShipTo"},{"documentLineLocationTypeId":6435041518,"documentLineId":12000501468,"documentAddressId":7390566442,"locationTypeCode":"ShipFrom"}],"hsCode":"","costInsuranceFreight":0.0000,"vatCode":"","vatNumberTypeId":0}],"addresses":[{"id":7390566442,"transactionId":10814105362,"boundaryLevel":"Address","line1":"822
+        Reed St","line2":"","line3":"","city":"Philadelphia","region":"PA","postalCode":"19147-5736","country":"US","taxRegionId":4014900,"latitude":"39.931649","longitude":"-75.159058"}],"locationTypes":[{"documentLocationTypeId":6645093308,"documentId":10814105362,"documentAddressId":7390566442,"locationTypeCode":"ShipTo"},{"documentLocationTypeId":4645093308,"documentId":10814105362,"documentAddressId":7390566442,"locationTypeCode":"ShipFrom"}],"summary":[{"country":"US","region":"PA","jurisType":"State","jurisCode":"42","jurisName":"PENNSYLVANIA","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Sales","taxSubType":"S","taxName":"PA
+        STATE TAX","rateType":"General","taxable":10.00,"rate":0.060000,"tax":0.60,"taxCalculated":0.60,"nonTaxable":0.00,"exemption":0.00},{"country":"US","region":"PA","jurisType":"County","jurisCode":"101","jurisName":"PHILADELPHIA","taxAuthorityType":45,"stateAssignedNo":"51","taxType":"Sales","taxSubType":"S","taxName":"PA
+        COUNTY TAX","rateType":"General","taxable":10.00,"rate":0.020000,"tax":0.20,"taxCalculated":0.20,"nonTaxable":0.00,"exemption":0.00}]}'
+    http_version:
+  recorded_at: Fri, 20 Sep 2019 09:02:49 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Currently `GetByCodeService` only accepts an order without a code
so custom transaction cannot be received using the service
Since the service is not coupled with Spree::Order it seems
logical to be able to pass a code into the service