### PR TITLE
Don't overwrite user_params and instead add them to spree strong parameters

### DIFF
--- a/app/controllers/spree/admin/users_controller_decorator.rb
+++ b/app/controllers/spree/admin/users_controller_decorator.rb
@@ -20,10 +20,6 @@ module Spree
 
         @use_codes = SpreeAvataxOfficial::EntityUseCode.all.map { |use_code| ["#{use_code.code} - #{use_code.name}", use_code.id] }
       end
-
-      def user_params
-        params.require(:user).permit(:avatax_entity_use_code_id, :exemption_number, :vat_id)
-      end
     end
   end
 end

--- a/config/initializers/spree_permitted_attributes.rb
+++ b/config/initializers/spree_permitted_attributes.rb
@@ -1,0 +1,5 @@
+module Spree
+  module PermittedAttributes
+    @@user_attributes.push :avatax_entity_use_code_id, :exemption_number, :vat_id
+  end
+end


### PR DESCRIPTION
Currently the way the the user controller decorator overrides `user_params` overwrites the other permitted params for users which removes the ability to edit things like email, password, and spree roles via the admin screen.

I am not sure this is the "best" way to do t his but it worked for me so I figured I would make a pull request.