### PR TITLE
Don't call reload on order

### DIFF
--- a/app/services/spree_avatax_official/create_tax_adjustments_service.rb
+++ b/app/services/spree_avatax_official/create_tax_adjustments_service.rb
@@ -5,7 +5,7 @@ module SpreeAvataxOfficial
     def call(order:) # rubocop:disable Metrics/AbcSize
       return failure(::Spree.t('spree_avatax_official.create_tax_adjustments.order_canceled')) if order.canceled?
 
-      order.reload.all_adjustments.tax.destroy_all
+      order.all_adjustments.tax.destroy_all
 
       return failure(::Spree.t('spree_avatax_official.create_tax_adjustments.tax_calculation_unnecessary')) unless order.avatax_tax_calculation_required?
 


### PR DESCRIPTION
The current version of the [Spree::OrderUpdater](https://github.com/spree/spree/blob/master/core/app/models/spree/order_updater.rb) works by setting a bunch of values on the in-memory instance of `Spree::Order`, running hooks and then persisting the changes at the end. This spree extension defines a hook that is calling `#reload` on the order, effectively wiping out the changes and preventing them from persisting. 

For example, the count on the cart isn't updating because `Spree::Order#item_count` isn't getting updated. Removing this call to `#reload` fixed the issue. I'm currently using this fork to get around the problem, but wanted to open a pull request to get some discussion around why this code initially existed and to better understand the impacts of removing this method call.

Any guidance would be greatly appreciated.