### PR TITLE
Fix zeitwerk name error

### DIFF
--- a/app/models/avatax/request_decorator.rb
+++ b/app/models/avatax/request_decorator.rb
@@ -1,4 +1,4 @@
-module AvaTax
+module Avatax
   module RequestDecorator
     include ::SpreeAvataxOfficial::HttpHelper
 
@@ -15,4 +15,4 @@ module AvaTax
 end
 
 # This is correct class to prepend because of: https://github.com/avadev/AvaTax-REST-V2-Ruby-SDK/blob/eb7c20b8e925a3d682f6414207e298e519e0a549/lib/avatax/api.rb#L25
-::AvaTax::API.prepend ::AvaTax::RequestDecorator
+::AvaTax::API.prepend ::Avatax::RequestDecorator


### PR DESCRIPTION
Hey, folks, thanks for your work!

We were getting the following error from zeitwerk due to the module being called `AvaTax` instead of `Avatax`:

```
uninitialized constant Avatax::RequestDecorator (NameError)
```

An alternative would be renaming the directory to `ava_tax`, I guess.