### PR TITLE
Use Spree.user_class in decorator

### DIFF
--- a/app/models/spree_avatax_official/spree/user_decorator.rb
+++ b/app/models/spree_avatax_official/spree/user_decorator.rb
@@ -8,4 +8,4 @@ module SpreeAvataxOfficial
   end
 end
 
-::Spree::User.prepend ::SpreeAvataxOfficial::Spree::UserDecorator
+::Spree.user_class.prepend ::SpreeAvataxOfficial::Spree::UserDecorator


### PR DESCRIPTION
:wave:

This PR changes the spree user decorator to use the `Spree.user_class` method instead of `Spree::User`.

In my `config/initializers/spree.rb` file, I have this line:

```
Spree.user_class = "User"
```

The user_class method is defined here: https://github.com/spree/spree/blob/main/core/lib/spree/core.rb#L31-L37,
and is present in tag `2.1.0` (the min spree version in the gemspec): https://github.com/spree/spree/blob/0a9385245e260057db93b65a379dc4f7fe00aa84/core/lib/spree/core.rb#L17-L23