### PR TITLE
fix: request decorator issue

### DIFF
--- a/app/models/avatax/request_decorator.rb
+++ b/app/models/avatax/request_decorator.rb
@@ -2,10 +2,12 @@ module Avatax
   module RequestDecorator
     include ::SpreeAvataxOfficial::HttpHelper
 
-    def request(method, path, model, options = {})
+    def request(method, path, model, options = {}, apiversion="", headers=Hash.new)
       max_retries                  ||= ::SpreeAvataxOfficial::Config.max_retries
       uri_encoded_path               = URI.parse(path).to_s
       response                       = connection.send(method) do |request|
+        request.headers['X-Avalara-Client'] = request.headers['X-Avalara-Client'].gsub("API_VERSION", apiversion)
+        request.headers=request.headers.merge(headers)  unless headers.empty?
         request.options['timeout'] ||= 1_200
         case method
         when :get, :delete


### PR DESCRIPTION
The problem stems from a recent update to the primary Avatax gem utilized in this project, which altered the number of accepted parameters in this specific location: [link to the relevant code](https://github.com/avadev/AvaTax-REST-V2-Ruby-SDK/blob/master/lib/avatax/request.rb#L25). Our current issue arises from this change, as it has led to a mismatch in parameter counts when working with the latest version on the master branch.