### PR TITLE
Infer default country from Store

### DIFF
--- a/app/controllers/spree/admin/avatax_settings_controller.rb
+++ b/app/controllers/spree/admin/avatax_settings_controller.rb
@@ -4,7 +4,7 @@ module Spree
       def edit
         @ship_from_address = SpreeAvataxOfficial::Config.ship_from_address
         @country = if @ship_from_address[:country].blank?
-                     Spree::Country.default
+                     Spree::Store.default.default_country
                    else
                      Spree::Country.find_by(iso3: @ship_from_address[:country])
                    end


### PR DESCRIPTION
### **What?**
Infer default country from Store instead of config.


### **Why?**
Spree no longer uses Spree::Config[:default_country_id] - it's now managed at per-store level.