### PR TITLE
Config template - skip logging to the file by default

### DIFF
--- a/lib/generators/spree_avatax_official/install/templates/config/initializers/spree_avatax_official.rb
+++ b/lib/generators/spree_avatax_official/install/templates/config/initializers/spree_avatax_official.rb
@@ -3,10 +3,16 @@ Rails.application.config.after_initialize do
   # Per-store credentials and settings are configured via the Avalara integration
   # in the Spree admin panel under Settings > Integrations.
   SpreeAvataxOfficial::Config.log            = true
-  SpreeAvataxOfficial::Config.log_to_stdout  = false
-  SpreeAvataxOfficial::Config.log_file_name  = 'avatax.log'
-  SpreeAvataxOfficial::Config.log_frequency  = 'weekly'
+  SpreeAvataxOfficial::Config.log_to_stdout  = true
   SpreeAvataxOfficial::Config.max_retries    = 2
   SpreeAvataxOfficial::Config.open_timeout   = 2.0
   SpreeAvataxOfficial::Config.read_timeout   = 6.0
+
+  # To log to a file instead of STDOUT, set `log_to_stdout = false` above and
+  # uncomment the settings below. `log_file_name` is the file written under
+  # `Rails.root/log/`, and `log_frequency` controls log rotation
+  # ('daily', 'weekly', or 'monthly').
+
+  # SpreeAvataxOfficial::Config.log_file_name = 'avatax.log'
+  # SpreeAvataxOfficial::Config.log_frequency = 'weekly'
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default logging configuration for Avalara tax integration to output to standard output instead of file-based logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree_avatax_official/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->