### PR TITLE
Guard against nil addresses in `SpreeAvataxOfficial::Address::Validate`

### DIFF
--- a/app/services/spree_avatax_official/address/validate.rb
+++ b/app/services/spree_avatax_official/address/validate.rb
@@ -5,7 +5,7 @@ module SpreeAvataxOfficial
       SUPPORTED_COUNTRIES = %w[US CA].freeze
 
       def call(address:, order:)
-        return success(nil) unless supported_country?(address)
+        return success(nil) if address.nil? || !supported_country?(address)
 
         response = send_request(address, order)
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -200,5 +200,19 @@ describe Spree::Order do
         end
       end
     end
+
+    context 'when there is no address' do
+      let(:ship_address) { nil }
+
+      it 'returns truthy without raising' do
+        avalara_integration.update!(active: false)
+        order
+        avalara_integration.update!(active: true)
+
+        expect(order.tax_address).to be_nil
+        expect { order.validate_tax_address }.not_to raise_error
+        expect(order.errors).to be_empty
+      end
+    end
   end
 end

--- a/spec/services/spree_avatax_official/address/validate_spec.rb
+++ b/spec/services/spree_avatax_official/address/validate_spec.rb
@@ -72,5 +72,18 @@ describe SpreeAvataxOfficial::Address::Validate, :avalara_integration do
         expect(response.value).to be_nil
       end
     end
+
+    context 'when the address is nil' do
+      let(:address) { nil }
+
+      it 'returns success without hitting Avalara' do
+        expect_any_instance_of(AvaTax::Client).not_to receive(:resolve_address) # rubocop:disable RSpec/AnyInstance
+
+        response = subject
+
+        expect(response.success?).to eq true
+        expect(response.value).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved address validation to properly handle cases where address information is not provided, preventing unnecessary processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree_avatax_official/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->